### PR TITLE
Fix bug that prevents `packages.find.exclude` to take effect when `include_package_data=True`

### DIFF
--- a/changelog.d/3261.breaking.rst
+++ b/changelog.d/3261.breaking.rst
@@ -1,0 +1,8 @@
+Projects that were abusing ``include_package_data=True`` to automatically add
+sub-packages and sub-modules will find the built wheel distribution no longer
+including some files.
+
+These projects are encouraged to properly configure ``packages`` to include all
+sub-packages. More information can be found in :doc:`userguide/package_discovery`.
+
+The previous behaviour was unintentional and caused a bug (#3260).

--- a/changelog.d/3261.change.rst
+++ b/changelog.d/3261.change.rst
@@ -1,0 +1,2 @@
+Fixed bug (#3260) that prevented configuration for ``packages.find.exclude`` to take effect
+when ``include_package_data = True``.

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -3,8 +3,12 @@ import stat
 import shutil
 
 import pytest
+import jaraco.path
+from path import Path
 
 from setuptools.dist import Distribution
+
+from .textwrap import DALS
 
 
 def test_directories_in_package_data_glob(tmpdir_cwd):
@@ -79,3 +83,50 @@ def test_executable_data(tmpdir_cwd):
 
     assert os.stat('build/lib/pkg/run-me').st_mode & stat.S_IEXEC, \
         "Script is not executable"
+
+
+def test_excluded_subpacakges(tmp_path):
+    files = {
+        "setup.cfg": DALS("""
+            [metadata]
+            name = mypkg
+            version = 42
+
+            [options]
+            include_package_data = True
+            packages = find:
+
+            [options.packages.find]
+            exclude = *.tests*
+            """),
+        "mypkg": {
+            "__init__.py": "",
+            "resource_file.txt": "",
+            "tests": {
+                "__init__.py": "",
+                "test_mypkg.py": "",
+                "test_file.txt": "",
+            }
+        },
+        "MANIFEST.in": DALS("""
+            global-include *.py *.txt
+            global-exclude *.py[cod]
+            prune dist
+            prune build
+            prune *.egg-info
+            """)
+    }
+
+    with Path(tmp_path):
+        jaraco.path.build(files)
+        dist = Distribution({"script_name": "%PEP 517%"})
+        dist.parse_config_files()
+        dist.run_command("build_py")
+        build_dir = Path(dist.get_command_obj("build_py").build_lib)
+
+        assert (build_dir / "mypkg/__init__.py").exists()
+        assert (build_dir / "mypkg/resource_file.txt").exists()
+        assert not (build_dir / "mypkg/tests/__init__.py").exists()
+        assert not (build_dir / "mypkg/tests/test_mypkg.py").exists()
+        assert not (build_dir / "mypkg/tests/test_file.txt").exists()
+        assert not (build_dir / "mypkg/tests").exists()


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

When discovering files in build_py, avoid including files and directories that correspond to a sub-package.

This way excluded sub-packages are automatically ignored.

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
