### PR TITLE
Rework PEP 660 PoC to re-use `bdist_wheel`

### DIFF
--- a/bootstrap.egg-info/entry_points.txt
+++ b/bootstrap.egg-info/entry_points.txt
@@ -2,6 +2,7 @@
 egg_info = setuptools.command.egg_info:egg_info
 build_py = setuptools.command.build_py:build_py
 sdist = setuptools.command.sdist:sdist
+editable_wheel = setuptools.command.editable_wheel:editable_wheel
 
 [distutils.setup_keywords]
 include_package_data = setuptools.dist:assert_bool

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -251,7 +251,6 @@ class _BuildMetaBackend:
                                          '.tar.gz', sdist_directory,
                                          config_settings)
 
-
     # PEP660 hooks:
     # build_editable
     # get_requires_for_build_editable
@@ -263,7 +262,6 @@ class _BuildMetaBackend:
         return self._build_with_temp_dir(
             ["editable_wheel"], ".whl", wheel_directory, config_settings
         )
-
 
     def get_requires_for_build_editable(self, config_settings=None):
         return ['editables', 'wheel']

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -257,7 +257,7 @@ class _BuildMetaBackend:
     # get_requires_for_build_editable
     # prepare_metadata_for_build_editable
     def build_editable(
-        self, wheel_directory, scheme=None, config_settings=None
+        self, wheel_directory, config_settings=None, metadata_directory=None
     ):
         # XXX can or should we hide our editable_wheel command normally?
         return self._build_with_temp_dir(

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -264,7 +264,13 @@ class _BuildMetaBackend:
         )
 
     def get_requires_for_build_editable(self, config_settings=None):
-        return ['editables', 'wheel']
+        return self.get_requires_for_build_wheel(config_settings)
+
+    def prepare_metadata_for_build_editable(self, metadata_directory,
+                                            config_settings=None):
+        return self.prepare_metadata_for_build_wheel(
+            metadata_directory, config_settings
+        )
 
 
 class _BuildMetaLegacyBackend(_BuildMetaBackend):
@@ -312,8 +318,9 @@ _BACKEND = _BuildMetaBackend()
 
 get_requires_for_build_wheel = _BACKEND.get_requires_for_build_wheel
 get_requires_for_build_sdist = _BACKEND.get_requires_for_build_sdist
-get_requires_for_build_editable =  _BACKEND.get_requires_for_build_editable
+get_requires_for_build_editable = _BACKEND.get_requires_for_build_editable
 prepare_metadata_for_build_wheel = _BACKEND.prepare_metadata_for_build_wheel
+prepare_metadata_for_build_editable = _BACKEND.prepare_metadata_for_build_editable
 build_wheel = _BACKEND.build_wheel
 build_sdist = _BACKEND.build_sdist
 build_editable = _BACKEND.build_editable

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -260,7 +260,8 @@ class _BuildMetaBackend:
     ):
         # XXX can or should we hide our editable_wheel command normally?
         return self._build_with_temp_dir(
-            ["editable_wheel"], ".whl", wheel_directory, config_settings
+            ["editable_wheel", "--dist-info-dir", metadata_directory],
+            ".whl", wheel_directory, config_settings
         )
 
     def get_requires_for_build_editable(self, config_settings=None):

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -62,10 +62,11 @@ class editable_wheel(Command):
             self.dist_info_dir = dist_info.dist_info_dir
         else:
             assert str(self.dist_info_dir).endswith(".dist-info")
-            assert list(Path(self.dist_info_dir).glob("*.dist-info/METADATA"))
+            assert Path(self.dist_info_dir, "METADATA").exists()
 
     def _create_wheel_file(self, bdist_wheel):
         from wheel.wheelfile import WheelFile
+
         dist_info = self.get_finalized_command("dist_info")
         tag = "-".join(bdist_wheel.get_tag())
         editable_name = dist_info.name

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -4,28 +4,12 @@ Create a wheel that, when installed, will make the source package 'editable'
 'setup.py develop'. Based on the setuptools develop command.
 """
 
-# TODO doesn't behave when called outside the hook
-
-import base64
 import os
-import time
-from pathlib import Path
-
+import shutil
+import sys
 from distutils.core import Command
-from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
-
-import pkg_resources
-from setuptools import __version__
-
-SOURCE_EPOCH_ZIP = 499162860
-
-WHEEL_FILE = f"""\
-Wheel-Version: 1.0
-Generator: setuptools ({__version__})
-Root-Is-Purelib: false
-Tag: py3-none-any
-Tag: ed-none-any
-"""
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 
 class editable_wheel(Command):
@@ -35,91 +19,78 @@ class editable_wheel(Command):
 
     user_options = [
         ("dist-dir=", "d", "directory to put final built distributions in"),
+        ("dist-info-dir=", "I", "path to a pre-build .dist-info directory"),
     ]
 
     boolean_options = []
 
-    def run(self):
-        self.build_editable_wheel()
-
     def initialize_options(self):
         self.dist_dir = None
+        self.dist_info_dir = None
+        self.project_dir = None
 
     def finalize_options(self):
-        self.dist_info = self.get_finalized_command("dist_info")
-        self.egg_base = self.dist_info.egg_base
-        self.dist_info_dir = Path(self.dist_info.dist_info_dir)
-        self.target = pkg_resources.normalize_path(self.egg_base)
+        dist = self.distribution
+        self.project_dir = dist.src_root or os.curdir
+        self.dist_dir = Path(self.dist_dir or os.path.join(self.project_dir, "dist"))
+        self.dist_dir.mkdir(exist_ok=True)
 
-    def build_editable_wheel(self):
-        if getattr(self.distribution, "use_2to3", False):
-            raise NotImplementedError("2to3 not supported")
+    @property
+    def target(self):
+        package_dir = self.distribution.package_dir or {}
+        return package_dir.get("") or self.project_dir
 
-        di = self.get_finalized_command("dist_info")
-        di.egg_base = self.dist_dir
-        di.finalize_options()
-        self.run_command("dist_info")
+    def run(self):
+        self._ensure_dist_info()
+
+        # Add missing dist_info files
+        bdist_wheel = self.reinitialize_command("bdist_wheel")
+        bdist_wheel.write_wheelfile(self.dist_info_dir)
 
         # Build extensions in-place
         self.reinitialize_command("build_ext", inplace=1)
         self.run_command("build_ext")
 
-        mtime = time.gmtime(SOURCE_EPOCH_ZIP)[:6]
+        self._create_wheel_file(bdist_wheel)
 
-        dist_dir = Path(self.dist_dir)
-        dist_info_dir = self.dist_info_dir
-        fullname = self.distribution.metadata.get_fullname()
-        # superfluous 'ed' tag is only a hint to the user,
-        # and guarantees we can't overwrite the normal wheel
-        wheel_name = f"{fullname}-ed.py3-none-any.whl"
-        wheel_path = dist_dir / wheel_name
+    def _ensure_dist_info(self):
+        if self.dist_info_dir is None:
+            dist_info = self.reinitialize_command("dist_info")
+            dist_info.output_dir = self.dist_dir
+            dist_info.finalize_options()
+            dist_info.run()
+            self.dist_info_dir = dist_info.dist_info_dir
+        else:
+            assert str(self.dist_info_dir).endswith(".dist-info")
+            assert list(Path(self.dist_info_dir).glob("*.dist-info/METADATA"))
 
+    def _create_wheel_file(self, bdist_wheel):
+        from wheel.wheelfile import WheelFile
+        dist_info = self.get_finalized_command("dist_info")
+        tag = "-".join(bdist_wheel.get_tag())
+        editable_name = dist_info.name
+        build_tag = "0.editable"  # According to PEP 427 needs to start with digit
+        archive_name = f"{editable_name}-{build_tag}-{tag}.whl"
+        wheel_path = Path(self.dist_dir, archive_name)
         if wheel_path.exists():
             wheel_path.unlink()
 
-        with ZipFile(wheel_path, "a", compression=ZIP_DEFLATED) as archive:
-            # copy .pth file
-            pth = ZipInfo(f"{fullname}_ed.pth", mtime)
-            archive.writestr(pth, f"{self.target}\n")
+        # Currently the wheel API receives a directory and dump all its contents
+        # inside of a wheel. So let's use a temporary directory.
+        with TemporaryDirectory(suffix=archive_name) as tmp:
+            tmp_dist_info = Path(tmp, Path(self.dist_info_dir).name)
+            shutil.copytree(self.dist_info_dir, tmp_dist_info)
+            pth = Path(tmp, f"_editable.{editable_name}.pth")
+            pth.write_text(f"{_normalize_path(self.target)}\n", encoding="utf-8")
 
-            # copy .dist-info directory
-            for f in sorted(os.listdir(dist_dir / dist_info_dir)):
-                with (dist_dir / dist_info_dir / f).open() as metadata:
-                    info = ZipInfo(str(dist_info_dir / f), mtime)
-                    archive.writestr(info, metadata.read())
+            with WheelFile(wheel_path, "w") as wf:
+                wf.write_files(tmp)
 
-            # Add WHEEL file
-            info = ZipInfo(str(dist_info_dir / "WHEEL"), mtime)
-            archive.writestr(info, WHEEL_FILE)
-
-            add_manifest(archive, dist_info_dir)
+        return wheel_path
 
 
-def urlsafe_b64encode(data):
-    """urlsafe_b64encode without padding"""
-    return base64.urlsafe_b64encode(data).rstrip(b"=")
-
-
-# standalone wheel helpers based on enscons
-def add_manifest(archive, dist_info_dir):
-    """
-    Add the wheel manifest.
-    """
-    import hashlib
-    import zipfile
-
-    lines = []
-    for f in archive.namelist():
-        data = archive.read(f)
-        size = len(data)
-        digest = hashlib.sha256(data).digest()
-        digest = "sha256=" + (urlsafe_b64encode(digest).decode("ascii"))
-        lines.append("%s,%s,%s" % (f.replace(",", ",,"), digest, size))
-
-    record_path = dist_info_dir / "RECORD"
-    lines.append(str(record_path) + ",,")
-    RECORD = "\n".join(lines)
-    archive.writestr(
-        zipfile.ZipInfo(str(record_path), time.gmtime(SOURCE_EPOCH_ZIP)[:6]), RECORD
-    )
-    archive.close()
+def _normalize_path(filename):
+    """Normalize a file/dir name for comparison purposes"""
+    # See pkg_resources.normalize_path
+    file = os.path.abspath(filename) if sys.platform == 'cygwin' else filename
+    return os.path.normcase(os.path.realpath(os.path.normpath(file)))

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 import pytest
 import jaraco.envs
+import jaraco.path
 import path
 
 
@@ -85,18 +86,17 @@ EXAMPLE = {
 
 
 SETUP_SCRIPT_STUB = "__import__('setuptools').setup()"
-MISSING_SETUP_SCRIPT = pytest.param(
-    None,
-    marks=pytest.mark.xfail(
-        reason="Editable install is currently only supported with `setup.py`"
-    )
+
+
+@pytest.mark.parametrize(
+    "files",
+    [
+        {**EXAMPLE, "setup.py": SETUP_SCRIPT_STUB},
+        EXAMPLE,  # No setup.py script
+    ]
 )
-
-
-@pytest.mark.parametrize("setup_script", [SETUP_SCRIPT_STUB, MISSING_SETUP_SCRIPT])
-def test_editable_with_pyproject(tmp_path, venv, setup_script):
+def test_editable_with_pyproject(tmp_path, venv, files):
     project = tmp_path / "mypkg"
-    files = {**EXAMPLE, "setup.py": setup_script}
     project.mkdir()
     jaraco.path.build(files, prefix=project)
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Avoid using the `editables` dependency
  - The current implementation is using it to simply place `.pth` file pointing to the project directory anyway...
  - Adding a dependency for creating a file with a single line is a bit overkill.
- Avoid importing `pkg_resources` directly
  - Setuptools wants to move away from `pkg_resources` 
- Replace custom wheel build with re-use of `bdist_wheel`
  - pro: avoid re-implementing the archiving logic and make sure it is compatible with the same archive format used by the final wheels.
  - con: the API of `wheel` is not exactly stable or exported as public. 

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
