### PR TITLE
Handle `namespace_packages` in `editable_wheel`

### DIFF
--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -100,23 +100,6 @@ class editable_wheel(Command):
 
         return wheel_path
 
-    def _best_strategy(self):
-        if self.strict:
-            return self._link_tree
-
-        dist = self.distribution
-        if set(dist.packages) == {""}:
-            # src-layout(ish) package detected. These kind of packages are relatively
-            # safe so we can simply add the src directory to the pth file.
-            return self._top_level_pth
-
-        if self._can_symlink():
-            return self._top_level_symlinks
-
-    # >>> def _targets(self):
-    # >>>     build_py.find_modules()
-    # >>>     self.dist.packages
-
     def _populate_wheel(self, dist_id, unpacked_wheel_dir):
         pth = Path(unpacked_wheel_dir, f"__editable__.{dist_id}.pth")
         pth.write_text(f"{self.target}\n", encoding="utf-8")


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This change is heavily inspired by the existing `develop` command

- Use `namespaces.Installer` to ensure legacy namespaces are handled.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
