### PR TITLE
Add tests for editable install focusing on namespaces

### DIFF
--- a/setuptools/tests/namespaces.py
+++ b/setuptools/tests/namespaces.py
@@ -28,6 +28,29 @@ def build_namespace_package(tmpdir, name):
     return src_dir
 
 
+def build_pep420_namespace_package(tmpdir, name):
+    src_dir = tmpdir / name
+    src_dir.mkdir()
+    pyproject = src_dir / "pyproject.toml"
+    namespace, sep, rest = name.rpartition(".")
+    script = f"""\
+        [build-system]
+        requires = ["setuptools"]
+        build-backend = "setuptools.build_meta"
+
+        [project]
+        name = "{name}"
+        version = "3.14159"
+        """
+    pyproject.write_text(textwrap.dedent(script), encoding='utf-8')
+    ns_pkg_dir = src_dir / namespace.replace(".", "/")
+    ns_pkg_dir.mkdir(parents=True)
+    pkg_mod = ns_pkg_dir / (rest + ".py")
+    some_functionality = f"name = {rest!r}"
+    pkg_mod.write_text(some_functionality, encoding='utf-8')
+    return src_dir
+
+
 def make_site_dir(target):
     """
     Add a sitecustomize.py module in target to cause

--- a/setuptools/tests/test_develop.py
+++ b/setuptools/tests/test_develop.py
@@ -5,12 +5,10 @@ import os
 import sys
 import subprocess
 import platform
-import pathlib
 
 from setuptools.command import test
 
 import pytest
-import pip_run.launch
 
 from setuptools.command.develop import develop
 from setuptools.dist import Distribution
@@ -165,45 +163,3 @@ class TestNamespaces:
         ]
         with test.test.paths_on_pythonpath([str(target)]):
             subprocess.check_call(pkg_resources_imp)
-
-    @pytest.mark.xfail(
-        platform.python_implementation() == 'PyPy',
-        reason="Workaround fails on PyPy (why?)",
-    )
-    def test_editable_prefix(self, tmp_path, sample_project):
-        """
-        Editable install to a prefix should be discoverable.
-        """
-        prefix = tmp_path / 'prefix'
-
-        # figure out where pip will likely install the package
-        site_packages = prefix / next(
-            pathlib.Path(path).relative_to(sys.prefix)
-            for path in sys.path
-            if 'site-packages' in path and path.startswith(sys.prefix)
-        )
-        site_packages.mkdir(parents=True)
-
-        # install workaround
-        pip_run.launch.inject_sitecustomize(str(site_packages))
-
-        env = dict(os.environ, PYTHONPATH=str(site_packages))
-        cmd = [
-            sys.executable,
-            '-m',
-            'pip',
-            'install',
-            '--editable',
-            str(sample_project),
-            '--prefix',
-            str(prefix),
-            '--no-build-isolation',
-        ]
-        subprocess.check_call(cmd, env=env)
-
-        # now run 'sample' with the prefix on the PYTHONPATH
-        bin = 'Scripts' if platform.system() == 'Windows' else 'bin'
-        exe = prefix / bin / 'sample'
-        if sys.version_info < (3, 8) and platform.system() == 'Windows':
-            exe = str(exe)
-        subprocess.check_call([exe], env=env)

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -119,11 +119,29 @@ class TestLegacyNamespaces:
         pkg_A = namespaces.build_namespace_package(tmp_path, 'myns.pkgA')
         pkg_B = namespaces.build_namespace_package(tmp_path, 'myns.pkgB')
         # use pip to install to the target directory
-        venv.run(["python", "-m", "pip", "install", str(pkg_A)])
-        venv.run(["python", "-m", "pip", "install", "-e", str(pkg_B)])
+        opts = ["--no-build-isolation"]  # force current version of setuptools
+        venv.run(["python", "-m", "pip", "install", str(pkg_A), *opts])
+        venv.run(["python", "-m", "pip", "install", "-e", str(pkg_B), *opts])
         venv.run(["python", "-c", "import myns.pkgA; import myns.pkgB"])
         # additionally ensure that pkg_resources import works
         venv.run(["python", "-c", "import pkg_resources"])
+
+
+class TestPep420Namespaces:
+
+    def test_namespace_package_importable(self, venv, tmp_path):
+        """
+        Installing two packages sharing the same namespace, one installed
+        normally using pip and the other installed in editable mode
+        should allow importing both packages.
+        """
+        pkg_A = namespaces.build_pep420_namespace_package(tmp_path, 'myns.n.pkgA')
+        pkg_B = namespaces.build_pep420_namespace_package(tmp_path, 'myns.n.pkgB')
+        # use pip to install to the target directory
+        opts = ["--no-build-isolation"]  # force current version of setuptools
+        venv.run(["python", "-m", "pip", "install", str(pkg_A), *opts])
+        venv.run(["python", "-m", "pip", "install", "-e", str(pkg_B), *opts])
+        venv.run(["python", "-c", "import myns.n.pkgA; import myns.n.pkgB"])
 
 
 # Moved here from test_develop:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Move `test_editable_prefix` from `test_develop` to `test_editable_install`
- Add more tests for editable install focusing on packages using namespaces (legacy or PEP 420)

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
