### PR TITLE
Add initial implementation of editable strategy based on a `MetaPathFinder` for top-level packages

### DIFF
--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -303,7 +303,7 @@ def _find_mapped_namespaces(pkg_roots: Dict[str, str]) -> Iterator[str]:
 def _remove_nested(pkg_roots: Dict[str, str]) -> Dict[str, str]:
     output = dict(pkg_roots.copy())
 
-    for pkg, path in reversed(pkg_roots.items()):
+    for pkg, path in reversed(list(pkg_roots.items())):
         if any(
             pkg != other and _is_nested(pkg, path, other, other_path)
             for other, other_path in pkg_roots.items()
@@ -389,7 +389,7 @@ class __EditableFinder:
         if fullname in cls.NAMESPACES:
             return cls._namespace_spec(fullname)
 
-        for pkg, pkg_path in reversed(cls.MAPPING.items()):
+        for pkg, pkg_path in reversed(list(cls.MAPPING.items())):
             if fullname.startswith(pkg):
                 return cls._find_spec(fullname, pkg, pkg_path)
 

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -42,8 +42,18 @@ import os
 from fnmatch import fnmatchcase
 from glob import glob
 from pathlib import Path
-from typing import TYPE_CHECKING
-from typing import Callable, Dict, Iterator, Iterable, List, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Union
+)
 
 import _distutils_hack.override  # noqa: F401
 
@@ -435,6 +445,7 @@ class ConfigDiscovery:
     def _ensure_no_accidental_inclusion(self, detected: List[str], kind: str):
         if len(detected) > 1:
             from inspect import cleandoc
+
             from setuptools.errors import PackageDiscoveryError
 
             msg = f"""Multiple top-level {kind} discovered in a flat-layout: {detected}.
@@ -527,7 +538,7 @@ def remove_stubs(packages: List[str]) -> List[str]:
 
 
 def find_parent_package(
-    packages: List[str], package_dir: Dict[str, str], root_dir: _Path
+    packages: List[str], package_dir: Mapping[str, str], root_dir: _Path
 ) -> Optional[str]:
     """Find the parent package that is not a namespace."""
     packages = sorted(packages, key=len)
@@ -550,7 +561,9 @@ def find_parent_package(
     return None
 
 
-def find_package_path(name: str, package_dir: Dict[str, str], root_dir: _Path) -> str:
+def find_package_path(
+    name: str, package_dir: Mapping[str, str], root_dir: _Path
+) -> str:
     """Given a package name, return the path where it should be found on
     disk, considering the ``package_dir`` option.
 

--- a/setuptools/tests/contexts.py
+++ b/setuptools/tests/contexts.py
@@ -123,3 +123,14 @@ def session_locked_tmp_dir(request, tmp_path_factory, name):
         # ^-- prevent multiple workers to access the directory at once
         locked_dir.mkdir(exist_ok=True, parents=True)
         yield locked_dir
+
+
+@contextlib.contextmanager
+def save_paths():
+    """Make sure initial `sys.path` and `sys.meta_path` are preserved"""
+    prev_paths = sys.path[:], sys.meta_path[:]
+
+    try:
+        yield
+    finally:
+        sys.path, sys.meta_path = prev_paths

--- a/setuptools/tests/contexts.py
+++ b/setuptools/tests/contexts.py
@@ -134,3 +134,16 @@ def save_paths():
         yield
     finally:
         sys.path, sys.meta_path = prev_paths
+
+
+@contextlib.contextmanager
+def remove_added_modules():
+    """Make sure modules are not stored in sys.modules"""
+    prev_modules = set(sys.modules)
+
+    try:
+        yield
+    finally:
+        extra_modules = set(sys.modules) - prev_modules
+        for mod in extra_modules:
+            sys.modules.pop(mod, None)

--- a/setuptools/tests/contexts.py
+++ b/setuptools/tests/contexts.py
@@ -127,7 +127,7 @@ def session_locked_tmp_dir(request, tmp_path_factory, name):
 
 @contextlib.contextmanager
 def save_paths():
-    """Make sure initial `sys.path` and `sys.meta_path` are preserved"""
+    """Make sure initial ``sys.path`` and ``sys.meta_path`` are preserved"""
     prev_paths = sys.path[:], sys.meta_path[:]
 
     try:
@@ -137,13 +137,12 @@ def save_paths():
 
 
 @contextlib.contextmanager
-def remove_added_modules():
-    """Make sure modules are not stored in sys.modules"""
-    prev_modules = set(sys.modules)
+def save_sys_modules():
+    """Make sure initial ``sys.modules`` is preserved"""
+    prev_modules = sys.modules
 
     try:
+        sys.modules = sys.modules.copy()
         yield
     finally:
-        extra_modules = set(sys.modules) - prev_modules
-        for mod in extra_modules:
-            sys.modules.pop(mod, None)
+        sys.modules = prev_modules

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -296,7 +296,7 @@ class TestFinderTemplate:
             assert mod1.a == 42
             assert mod2.a == 43
             expected = str((tmp_path / "src1/pkg1/subpkg").resolve())
-            assert str(Path(subpkg.__path__[0]).resolve()) == expected
+            self.assert_path(subpkg, expected)
 
     def test_namespace(self, tmp_path):
         files = {"pkg": {"__init__.py": "a = 13", "text.txt": "abc"}}
@@ -312,7 +312,7 @@ class TestFinderTemplate:
             text = importlib_resources.files(pkg) / "text.txt"
 
             expected = str((tmp_path / "pkg").resolve())
-            assert str(Path(pkg.__path__[0]).resolve()) == expected
+            self.assert_path(pkg, expected)
             assert pkg.a == 13
 
             # Make sure resources can also be found
@@ -337,9 +337,15 @@ class TestFinderTemplate:
             mod2 = import_module("ns.mod2")
 
             expected = str((tmp_path / "src1/ns/pkg1").resolve())
-            assert str(Path(pkgA.__path__[0]).resolve()) == expected
+            self.assert_path(pkgA, expected)
             assert pkgA.a == 13
             assert mod2.b == 37
+
+    def assert_path(self, pkg, expected):
+        if pkg.__path__:
+            path = next(iter(pkg.__path__), None)
+            if path:
+                assert str(Path(path).resolve()) == expected
 
 
 def test_pkg_roots(tmp_path):

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -287,7 +287,10 @@ class TestFinderTemplate:
         }
         template = _finder_template(mapping, {})
 
-        with contexts.save_paths(), contexts.remove_added_modules():
+        with contexts.save_paths(), contexts.save_sys_modules():
+            for mod in ("pkg1", "pkg1.subpkg", "pkg1.subpkg.mod1", "mod2"):
+                sys.modules.pop(mod, None)
+
             self.install_finder(template)
             mod1 = import_module("pkg1.subpkg.mod1")
             mod2 = import_module("mod2")
@@ -306,7 +309,10 @@ class TestFinderTemplate:
         namespaces = {"ns"}
 
         template = _finder_template(mapping, namespaces)
-        with contexts.save_paths(), contexts.remove_added_modules():
+        with contexts.save_paths(), contexts.save_sys_modules():
+            for mod in ("ns", "ns.othername"):
+                sys.modules.pop(mod, None)
+
             self.install_finder(template)
             pkg = import_module("ns.othername")
             text = importlib_resources.files(pkg) / "text.txt"
@@ -331,7 +337,10 @@ class TestFinderTemplate:
         }
         template = _finder_template(mapping, {})
 
-        with contexts.save_paths(), contexts.remove_added_modules():
+        with contexts.save_paths(), contexts.save_sys_modules():
+            for mod in ("ns", "ns.pkgA", "ns.mod2"):
+                sys.modules.pop(mod, None)
+
             self.install_finder(template)
             pkgA = import_module("ns.pkgA")
             mod2 = import_module("ns.mod2")


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Add improvements and small fixes for the static `.pth` file strategy
- Add initial implementation of an editable strategy based on `MetaPathFinder` but just for the top-level packages/modules
  - The idea here is to create a "loose/lax" mechanism that is able to handle the complex mapping mechanisms supported by setuptools (via `package_dir`) while still allowing new modules and files to be added to existing packages.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
