### PR TITLE
Add implementation of editable strategy based on a link tree

### DIFF
--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -3,7 +3,6 @@ import sys
 import itertools
 from importlib.machinery import EXTENSION_SUFFIXES
 from distutils.command.build_ext import build_ext as _du_build_ext
-from distutils.file_util import copy_file
 from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler, get_config_var
 from distutils.errors import DistutilsError
@@ -96,10 +95,7 @@ class build_ext(_build_ext):
             # Always copy, even if source is older than destination, to ensure
             # that the right extensions for the current Python/platform are
             # used.
-            copy_file(
-                src_filename, dest_filename, verbose=self.verbose,
-                dry_run=self.dry_run
-            )
+            build_py.copy_file(src_filename, dest_filename)
             if ext._needs_stub:
                 self.write_stub(package_dir or os.curdir, ext, True)
 

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -33,6 +33,17 @@ class build_py(orig.build_py):
         if 'data_files' in self.__dict__:
             del self.__dict__['data_files']
         self.__updated_files = []
+        self.use_links = None
+
+    def copy_file(self, infile, outfile, preserve_mode=1, preserve_times=1,
+                  link=None, level=1):
+        # Overwrite base class to allow using links
+        link = getattr(self, "use_links", None) if link is None else link
+        if link:
+            infile = str(Path(infile).resolve())
+            outfile = str(Path(outfile).resolve())
+        return super().copy_file(infile, outfile, preserve_mode,
+                                 preserve_times, link, level)
 
     def run(self):
         """Build modules, packages, and copy data files to build directory"""

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -47,6 +47,7 @@ class editable_wheel(Command):
     user_options = [
         ("dist-dir=", "d", "directory to put final built distributions in"),
         ("dist-info-dir=", "I", "path to a pre-build .dist-info directory"),
+        ("strict", None, "perform an strict installation"),
     ]
 
     boolean_options = ["strict"]
@@ -211,6 +212,9 @@ class _LinkTree(_StaticPth):
         self.tmp = tmp
 
     def _build_py(self):
+        if not self.dist.has_pure_modules():
+            return
+
         build_py = self.dist.get_command_obj("build_py")
         build_py.ensure_finalized()
         # Force build_py to use links instead of copying files
@@ -218,6 +222,9 @@ class _LinkTree(_StaticPth):
         build_py.run()
 
     def _build_ext(self):
+        if not self.dist.has_ext_modules():
+            return
+
         build_ext = self.dist.get_command_obj("build_ext")
         build_ext.ensure_finalized()
         # Extensions are not editable, so we just have to build them in the right dir
@@ -256,6 +263,11 @@ def _configure_build(name: str, dist: Distribution, target_dir: _Path, tmp_dir: 
     data = str(Path(target_dir, f"{name}.data", "data"))
     headers = str(Path(target_dir, f"{name}.data", "include"))
     scripts = str(Path(target_dir, f"{name}.data", "scripts"))
+
+    # egg-info will be generated again to create a manifest (used for package data)
+    egg_info = dist.reinitialize_command("egg_info", reinit_subcommands=True)
+    egg_info.egg_base = str(tmp_dir)
+    egg_info.ignore_egg_info_in_manifest = True
 
     build = dist.reinitialize_command("build", reinit_subcommands=True)
     install = dist.reinitialize_command("install", reinit_subcommands=True)

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -182,6 +182,7 @@ class egg_info(InfoCommon, Command):
         self.egg_info = None
         self.egg_version = None
         self.broken_egg_info = False
+        self.ignore_egg_info_in_manifest = False
 
     ####################################
     # allow the 'tag_svn_revision' to be detected and
@@ -311,6 +312,7 @@ class egg_info(InfoCommon, Command):
         """Generate SOURCES.txt manifest file"""
         manifest_filename = os.path.join(self.egg_info, "SOURCES.txt")
         mm = manifest_maker(self.distribution)
+        mm.ignore_egg_info_dir = self.ignore_egg_info_in_manifest
         mm.manifest = manifest_filename
         mm.run()
         self.filelist = mm.filelist
@@ -333,6 +335,10 @@ class egg_info(InfoCommon, Command):
 
 class FileList(_FileList):
     # Implementations of the various MANIFEST.in commands
+
+    def __init__(self, warn=None, debug_print=None, ignore_egg_info_dir=False):
+        super().__init__(warn, debug_print)
+        self.ignore_egg_info_dir = ignore_egg_info_dir
 
     def process_template_line(self, line):
         # Parse the line: split it up, make sure the right number of words
@@ -523,6 +529,10 @@ class FileList(_FileList):
             return False
 
         try:
+            # ignore egg-info paths
+            is_egg_info = ".egg-info" in u_path or b".egg-info" in utf8_path
+            if self.ignore_egg_info_dir and is_egg_info:
+                return False
             # accept is either way checks out
             if os.path.exists(u_path) or os.path.exists(utf8_path):
                 return True
@@ -539,12 +549,13 @@ class manifest_maker(sdist):
         self.prune = 1
         self.manifest_only = 1
         self.force_manifest = 1
+        self.ignore_egg_info_dir = False
 
     def finalize_options(self):
         pass
 
     def run(self):
-        self.filelist = FileList()
+        self.filelist = FileList(ignore_egg_info_dir=self.ignore_egg_info_dir)
         if not os.path.exists(self.manifest):
             self.write_manifest()  # it must exist so it'll get in the list
         self.add_defaults()

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -16,7 +16,7 @@ from . import contexts, namespaces
 from setuptools._importlib import resources as importlib_resources
 from setuptools.command.editable_wheel import (
     _finder_template,
-    _find_pkg_roots,
+    _find_package_roots,
     _find_mapped_namespaces,
 )
 
@@ -383,7 +383,7 @@ def test_pkg_roots(tmp_path):
     jaraco.path.build(files, prefix=tmp_path)
     package_dir = {"a.b.c": "other", "a.b.c.x.y": "another"}
     packages = ["a", "a.b", "a.b.c", "a.b.c.x.y", "d", "d.e", "f", "f.g", "f.g.h"]
-    roots = _find_pkg_roots(packages, package_dir, tmp_path)
+    roots = _find_package_roots(packages, package_dir, tmp_path)
     assert roots == {
         "a": str(tmp_path / "a"),
         "a.b.c": str(tmp_path / "other"),

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import sys
 import subprocess
 import platform
@@ -318,7 +319,7 @@ class TestFinderTemplate:
             assert mod1.a == 42
             assert mod2.a == 43
             expected = str((tmp_path / "src1/pkg1/subpkg").resolve())
-            self.assert_path(subpkg, expected)
+            assert_path(subpkg, expected)
 
     def test_namespace(self, tmp_path):
         files = {"pkg": {"__init__.py": "a = 13", "text.txt": "abc"}}
@@ -337,7 +338,7 @@ class TestFinderTemplate:
             text = importlib_resources.files(pkg) / "text.txt"
 
             expected = str((tmp_path / "pkg").resolve())
-            self.assert_path(pkg, expected)
+            assert_path(pkg, expected)
             assert pkg.a == 13
 
             # Make sure resources can also be found
@@ -365,15 +366,9 @@ class TestFinderTemplate:
             mod2 = import_module("ns.mod2")
 
             expected = str((tmp_path / "src1/ns/pkg1").resolve())
-            self.assert_path(pkgA, expected)
+            assert_path(pkgA, expected)
             assert pkgA.a == 13
             assert mod2.b == 37
-
-    def assert_path(self, pkg, expected):
-        if pkg.__path__:
-            path = next(iter(pkg.__path__), None)
-            if path:
-                assert str(Path(path).resolve()) == expected
 
 
 def test_pkg_roots(tmp_path):
@@ -545,7 +540,7 @@ class TestLinkTree:
 
             mod1 = next(build.glob("**/mod1.py"))
             expected = tmp_path / "src/mypkg/mod1.py"
-            assert str(mod1.resolve()) == str(expected.resolve())
+            assert_link_to(mod1, expected)
 
             # Ensure excluded packages don't show up
             assert next(build.glob("**/subpackage"), None) is None
@@ -592,3 +587,24 @@ def install_project(name, venv, tmp_path, files):
     opts = ["--no-build-isolation"]  # force current version of setuptools
     venv.run(["python", "-m", "pip", "install", "-e", str(project), *opts])
     return project
+
+
+# ---- Assertion Helpers ----
+
+
+def assert_path(pkg, expected):
+    # __path__ is not guaranteed to exist, so we have to account for that
+    if pkg.__path__:
+        path = next(iter(pkg.__path__), None)
+        if path:
+            assert str(Path(path).resolve()) == expected
+
+
+def assert_link_to(file: Path, other: Path):
+    if file.is_symlink():
+        assert str(file.resolve()) == str(other.resolve())
+    else:
+        file_stat = file.stat()
+        other_stat = other.stat()
+        assert file_stat[stat.ST_INO] == other_stat[stat.ST_INO]
+        assert file_stat[stat.ST_DEV] == other_stat[stat.ST_DEV]

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -65,6 +65,8 @@ EXAMPLE = {
     "MANIFEST.in": dedent("""\
         global-include *.py *.txt
         global-exclude *.py[cod]
+        prune dist
+        prune build
         """).strip(),
     "README.rst": "This is a ``README``",
     "LICENSE.txt": "---- placeholder MIT license ----",
@@ -413,14 +415,9 @@ class TestOverallBehaviour:
         version = "3.14159"
         """
 
-    MANIFEST = """\
-    global-include *.py *.txt
-    global-exclude *.py[cod]
-    """
-
     FLAT_LAYOUT = {
         "pyproject.toml": dedent(PYPROJECT),
-        "MANIFEST.in": dedent(MANIFEST),
+        "MANIFEST.in": EXAMPLE["MANIFEST.in"],
         "otherfile.py": "",
         "mypkg": {
             "__init__.py": "",
@@ -437,7 +434,7 @@ class TestOverallBehaviour:
         "flat-layout": FLAT_LAYOUT,
         "src-layout": {
             "pyproject.toml": dedent(PYPROJECT),
-            "MANIFEST.in": dedent(MANIFEST),
+            "MANIFEST.in": EXAMPLE["MANIFEST.in"],
             "otherfile.py": "",
             "src": {"mypkg": FLAT_LAYOUT["mypkg"]},
         },
@@ -449,7 +446,7 @@ class TestOverallBehaviour:
                 [tool.setuptools.package-dir]
                 "mypkg.subpackage" = "other"
                 """),
-            "MANIFEST.in": dedent(MANIFEST),
+            "MANIFEST.in": EXAMPLE["MANIFEST.in"],
             "otherfile.py": "",
             "mypkg": {
                 "__init__.py": "",
@@ -459,7 +456,7 @@ class TestOverallBehaviour:
         },
         "namespace": {
             "pyproject.toml": dedent(PYPROJECT),
-            "MANIFEST.in": dedent(MANIFEST),
+            "MANIFEST.in": EXAMPLE["MANIFEST.in"],
             "otherfile.py": "",
             "src": {
                 "mypkg": {
@@ -525,7 +522,7 @@ class TestLinkTree:
     FILES["pyproject.toml"] += dedent("""\
         [tool.setuptools.packages.find]
         where = ["src"]
-        exclude = ["*.subpackage.*"]
+        exclude = ["*.subpackage*"]
         """)
     FILES["src"]["mypkg"]["resource.not_in_manifest"] = "abc"
 
@@ -538,15 +535,19 @@ class TestLinkTree:
             dist.parse_config_files()
 
             build = tmp_path / ".build"
+            tmp = tmp_path / ".tmp"
+            tmp.mkdir()
             unpacked = tmp_path / ".unpacked"
             unpacked.mkdir()
 
-            make_tree = _LinkTree(dist, name, build, tmp_path / ".tmp")
+            make_tree = _LinkTree(dist, name, build, tmp)
             make_tree(unpacked)
 
             mod1 = next(build.glob("**/mod1.py"))
-            assert str(mod1.resolve()) == str((tmp_path / "mypkg/mod1.py").resolve())
+            expected = tmp_path / "src/mypkg/mod1.py"
+            assert str(mod1.resolve()) == str(expected.resolve())
 
+            # Ensure excluded packages don't show up
             assert next(build.glob("**/subpackage"), None) is None
             assert next(build.glob("**/mod2.py"), None) is None
             assert next(build.glob("**/resource_file.txt"), None) is None
@@ -567,7 +568,7 @@ class TestLinkTree:
             print(ex)
         """
         out = venv.run(["python", "-c", dedent(cmd_import_error)])
-        assert b"No module named 'mypkg.subpackage'" in out
+        assert b"cannot import name 'subpackage'" in out
 
         # Ensure resource files excluded from distribution are not reachable
         cmd_get_resource = """\


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Add implementation of editable strategy based on a link tree
  - This is the `strict` implementation.
  - Only files are linked, not directories.
    - This approach makes it possible to use harlinks when softlinks are not available (e.g. Windows) 
    - It also guarantees files that would not be part of the final wheel are not available in the editable install.
- Add non-editable files to the produced wheel wheel (e.g. `headers`, `scripts`, `data`)


Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
