### PR TITLE
Editable rework `dist_info` to use `--output-dir` instead of `--egg-base`

### DIFF
--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -185,7 +185,7 @@ class _BuildMetaBackend:
     def prepare_metadata_for_build_wheel(self, metadata_directory,
                                          config_settings=None):
         sys.argv = sys.argv[:1] + [
-            'dist_info', '--egg-base', metadata_directory]
+            'dist_info', '--output-dir', metadata_directory]
         with no_install_setup_requires():
             self.run_setup()
 

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -24,23 +24,24 @@ class dist_info(Command):
 
     def initialize_options(self):
         self.egg_base = None
+        self.dist_info_dir = None
 
     def finalize_options(self):
-        pass
-
-    def run(self):
         egg_info = self.get_finalized_command('egg_info')
         egg_info.egg_base = self.egg_base
         egg_info.finalize_options()
-        egg_info.run()
         name = _safe(self.distribution.get_name())
-        version = _version(self.distribution.get_version())
         base = self.egg_base or os.curdir
-        dist_info_dir = os.path.join(base, f"{name}-{version}.dist-info")
-        log.info("creating '{}'".format(os.path.abspath(dist_info_dir)))
+        version = _version(self.distribution.get_version())
+        self.dist_info_dir = os.path.join(base, f"{name}-{version}.dist-info")
+        self.egg_info = egg_info
+        self.egg_base = egg_info.egg_base
 
+    def run(self):
+        self.egg_info.run()
+        log.info("creating '{}'".format(os.path.abspath(self.dist_info_dir)))
         bdist_wheel = self.get_finalized_command('bdist_wheel')
-        bdist_wheel.egg2dist(egg_info.egg_info, dist_info_dir)
+        bdist_wheel.egg2dist(self.egg_info.egg_info, self.dist_info_dir)
 
 
 def _safe(component: str) -> str:

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -7,6 +7,7 @@ import os
 import re
 import warnings
 from inspect import cleandoc
+from pathlib import Path
 
 from distutils.core import Command
 from distutils import log
@@ -40,10 +41,11 @@ class dist_info(Command):
 
         dist = self.distribution
         project_dir = dist.src_root or os.curdir
-        self.output_dir = self.output_dir or project_dir
+        self.output_dir = Path(self.output_dir or project_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
 
         egg_info = self.reinitialize_command('egg_info')
-        egg_info.egg_base = self.output_dir
+        egg_info.egg_base = str(self.output_dir)
         egg_info.finalize_options()
         self.egg_info = egg_info
 

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -11,6 +11,7 @@ from inspect import cleandoc
 from distutils.core import Command
 from distutils import log
 from setuptools.extern import packaging
+from setuptools._deprecation_warning import SetuptoolsDeprecationWarning
 
 
 class dist_info(Command):
@@ -19,29 +20,45 @@ class dist_info(Command):
 
     user_options = [
         ('egg-base=', 'e', "directory containing .egg-info directories"
-                           " (default: top of the source tree)"),
+                           " (default: top of the source tree)"
+                           " DEPRECATED: use --output-dir."),
+        ('output-dir=', 'o', "directory inside of which the .dist-info will be"
+                             "created (default: top of the source tree)"),
     ]
 
     def initialize_options(self):
         self.egg_base = None
+        self.output_dir = None
+        self.name = None
         self.dist_info_dir = None
 
     def finalize_options(self):
-        egg_info = self.get_finalized_command('egg_info')
-        egg_info.egg_base = self.egg_base
+        if self.egg_base:
+            msg = "--egg-base is deprecated for dist_info command. Use --output-dir."
+            warnings.warn(msg, SetuptoolsDeprecationWarning)
+            self.output_dir = self.egg_base or self.output_dir
+
+        dist = self.distribution
+        project_dir = dist.src_root or os.curdir
+        self.output_dir = self.output_dir or project_dir
+
+        egg_info = self.reinitialize_command('egg_info')
+        egg_info.egg_base = self.output_dir
         egg_info.finalize_options()
-        name = _safe(self.distribution.get_name())
-        base = self.egg_base or os.curdir
-        version = _version(self.distribution.get_version())
-        self.dist_info_dir = os.path.join(base, f"{name}-{version}.dist-info")
         self.egg_info = egg_info
-        self.egg_base = egg_info.egg_base
+
+        name = _safe(dist.get_name())
+        version = _version(dist.get_version())
+        self.name = f"{name}-{version}"
+        self.dist_info_dir = os.path.join(self.output_dir, f"{self.name}.dist-info")
 
     def run(self):
         self.egg_info.run()
+        egg_info_dir = self.egg_info.egg_info
         log.info("creating '{}'".format(os.path.abspath(self.dist_info_dir)))
         bdist_wheel = self.get_finalized_command('bdist_wheel')
-        bdist_wheel.egg2dist(self.egg_info.egg_info, self.dist_info_dir)
+        bdist_wheel.egg2dist(egg_info_dir, self.dist_info_dir)
+        assert os.path.exists(egg_info_dir) is False
 
 
 def _safe(component: str) -> str:

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -42,7 +42,6 @@ class dist_info(Command):
         dist = self.distribution
         project_dir = dist.src_root or os.curdir
         self.output_dir = Path(self.output_dir or project_dir)
-        self.output_dir.mkdir(parents=True, exist_ok=True)
 
         egg_info = self.reinitialize_command('egg_info')
         egg_info.egg_base = str(self.output_dir)
@@ -55,6 +54,7 @@ class dist_info(Command):
         self.dist_info_dir = os.path.join(self.output_dir, f"{self.name}.dist-info")
 
     def run(self):
+        self.output_dir.mkdir(parents=True, exist_ok=True)
         self.egg_info.run()
         egg_info_dir = self.egg_info.egg_info
         log.info("creating '{}'".format(os.path.abspath(self.dist_info_dir)))

--- a/setuptools/tests/test_dist_info.py
+++ b/setuptools/tests/test_dist_info.py
@@ -91,6 +91,15 @@ class TestDistInfo:
         dist_info = next(tmp_path.glob("*.dist-info"))
         assert dist_info.name.startswith("proj-42")
 
+    def test_output_dir(self, tmp_path):
+        config = "[metadata]\nname=proj\nversion=42\n"
+        (tmp_path / "setup.cfg").write_text(config, encoding="utf-8")
+        out = (tmp_path / "__out")
+        out.mkdir()
+        run_command("dist_info", "--output-dir", str(out), cwd=tmp_path)
+        assert len(list(out.glob("*.dist-info"))) == 1
+        assert len(list(tmp_path.glob("*.dist-info"))) == 0
+
 
 class TestWheelCompatibility:
     """Make sure the .dist-info directory produced with the ``dist_info`` command


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Deprecate the `--egg-base` parameter for `dist_info` and add `--output-dir` as replacement
  (Since the egg format is mostly deprecated, it is nice to move away from this nomenclature...)

**NOTE**: The CI for this PR is expected to fail because the original PoC for  PEP 660 is failing.
This is fixed in the follow up PR https://github.com/abravalheri/setuptools/pull/3. See ca8dad64570862fadc5a85988d851bd0fda51d8b and 57f01a9802018c0d9d9e3c48c5ef6f3cea790365.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
